### PR TITLE
Auto update

### DIFF
--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -40,7 +40,6 @@ $(function(){
   var reloadMessages = function() {
     if (window.location.href.match(/\/groups\/\d+\/messages/)){
       var last_message_id =  $('.message:last').data("message-id");
-      console.log(last_message_id);
       $.ajax({
         url: "api/messages",
         type: 'get',

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,7 +1,7 @@
 $(function(){
   function buildHTML(message){
     var img = message.image ? `<img src= ${message.image}>` : "";
-    var html = `<div class="message">
+    var html = `<div class="message" data-message-id="${message.id}">
                   <div class="message__upper-info">
                     <div class="message__upper-info__talker">${message.user_name}</div>
                     <div class="message__upper-info__date">${message.created_at}</div>
@@ -13,6 +13,7 @@ $(function(){
                 </div>`
     return html;
   }
+
   $('#new_message').on('submit', function(e){
     e.preventDefault();
     var formData = new FormData(this);
@@ -29,12 +30,35 @@ $(function(){
       var html = buildHTML(message);
       $('.messages').append(html);
       $('#new_message.new_message')[0].reset();
-      $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight},500);
+      $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight},'fast');
     })
-    
     .fail(function(){
       alert('エラーが発生しメッセージが送信できませんでした。');
-    })
-  
+    });
   })
-})
+
+  var reloadMessages = function() {
+    if (window.location.href.match(/\/groups\/\d+\/messages/)){
+      var last_message_id =  $('.message:last').data("message-id");
+      console.log(last_message_id);
+      $.ajax({
+        url: "api/messages",
+        type: 'get',
+        dataType: 'json',
+        data: {id: last_message_id}
+      })
+      .done(function(messages) {
+        var insertHTML = '';
+        messages.forEach(function (message) {
+          insertHTML = buildHTML(message); 
+          $('.messages').append(insertHTML);
+        })
+        $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
+      })
+      .fail(function() {
+        alert('自動更新に失敗しました');
+      });
+    }
+  };
+  setInterval(reloadMessages, 5000);
+});

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,9 @@
+class Api::MessagesController < ApplicationController
+  protect_from_forgery
+  
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,8 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
-
+  protect_from_forgery
+  
   protected
 
   def configure_permitted_parameters

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content    message.content
+  json.image      message.image.url
+  json.created_at message.created_at.strftime("%Y/%m/%d %H:%M")
+  json.user_name  message.user.name
+  json.id         message.id
+end

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,6 @@
-json.content @message.content
+json.(@message, :content, :image)
+json.content    @message.content
 json.created_at @message.created_at.strftime("%Y/%m/%d %H:%M")
 json.user_name  @message.user.name
-json.image @message.image.url
+json.id         @message.id
+json.image      @message.image.url

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:edit, :update, :index]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
＃what 
メッセージの投稿のさいに、他のユーザーも自動でメッセージを更新できるようにした。
メッセージのHTMLにカスタムデータでIDを持たせて、最後の投稿のIDを取得、表示スクロール。

＃why
チャット機能として成り立たせるため。


https://gyazo.com/ffbba2ca82ef8a8f4a3177424be1fa2a
